### PR TITLE
Do not capitalize error string

### DIFF
--- a/release.go
+++ b/release.go
@@ -158,14 +158,14 @@ func header_compressed_nomemcopy(w io.Writer) error {
 func bindataRead(data, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(strings.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("Read %%q: %%v", name, err)
+		return nil, fmt.Errorf("read %%q: %%v", name, err)
 	}
 
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, gz)
 
 	if err != nil {
-		return nil, fmt.Errorf("Read %%q: %%v", name, err)
+		return nil, fmt.Errorf("read %%q: %%v", name, err)
 	}
 
 	clErr := gz.Close()
@@ -197,7 +197,7 @@ func header_compressed_memcopy(w io.Writer) error {
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("Read %%q: %%v", name, err)
+		return nil, fmt.Errorf("read %%q: %%v", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -205,7 +205,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("Read %%q: %%v", name, err)
+		return nil, fmt.Errorf("read %%q: %%v", name, err)
 	}
 	if clErr != nil {
 		return nil, err

--- a/testdata/out/compress-memcopy.go
+++ b/testdata/out/compress-memcopy.go
@@ -23,7 +23,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("Read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -31,7 +31,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("Read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 	if clErr != nil {
 		return nil, err

--- a/testdata/out/compress-nomemcopy.go
+++ b/testdata/out/compress-nomemcopy.go
@@ -23,14 +23,14 @@ import (
 func bindataRead(data, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(strings.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("Read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, gz)
 
 	if err != nil {
-		return nil, fmt.Errorf("Read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 
 	clErr := gz.Close()


### PR DESCRIPTION
This makes the code generated by go-bindata conform to this advise
https://github.com/golang/go/wiki/CodeReviewComments#error-strings

honnef.co/tools@next also enforces this in its style guide checks, so the next
version of megacheck will enforce this (used by this project).