### PR TITLE
Fix asset path bug when including files outside of the prefix

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -199,7 +199,11 @@ func findFiles(dir, prefix string, recursive bool, toc *[]Asset, ignore []*regex
 		if strings.HasPrefix(asset.Name, prefix) {
 			asset.Name = asset.Name[len(prefix):]
 		} else {
-			asset.Name = filepath.Join(dir, file.Name())
+			if fi.IsDir() {
+				asset.Name = filepath.Join(dir, file.Name())
+			} else {
+				asset.Name = dir
+			}
 		}
 
 		// If we have a leading slash, get rid of it.

--- a/convert_test.go
+++ b/convert_test.go
@@ -55,7 +55,7 @@ func TestFindFilesOutsidePrefix(t *testing.T) {
 		t.Errorf("expected to find one item, got %d", len(toc))
 	}
 	item := toc[0]
-	want := "testdata/in/test.asset/test.asset"
+	want := "testdata/in/test.asset"
 	if item.Name != want {
 		t.Errorf("expected Name to be %q, got %q", want, item.Name)
 	}


### PR DESCRIPTION
Before this patch, if you ran this command:

```
./go-bindata -o files.go -pkg files -prefix testdata/assets testdata/assets/* testdata/in/*
```

The asset paths would look like:

```
   bindata.go (from testdata/assets)
   testdata/in/a/test.asset
   testdata/in/b/test.asset
   testdata/in/c/test.asset
   testdata/in/test.asset/test.asset
```

For the test.asset file in testdata/in it made a new directory with the
same name as the asset.

After this patch is looks like:

```
   bindata.go (from testdata/assets)
   testdata/in/a/test.asset
   testdata/in/b/test.asset
   testdata/in/c/test.asset
   testdata/in/test.asset
```

This is because when processing the files from the "in/*" glob it
treated evey value as a directory and appened the file name, even though
test.asset is already a file. This only occurs when using a prefix
because when the prefix is empty we use relative paths and fall back to
using the original asset.Name.