### PR TITLE
introduce go module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kevinburke/go-bindata
+
+go 1.14


### PR DESCRIPTION
Go modules are an integral part of the golang toolchain. They allow easy
fixation of versions. In addition, projects can be compiled without a configured
GOPATH.

With this change the project of course remains backward compatible.

SEE: https://github.com/golang/go/wiki/Modules

```bash
$ pwd                                           
/home/frzifus/git/test
$ pushd go-bindata
$ go build -v
main.go:15:2: cannot find package "github.com/kevinburke/go-bindata" in any of:
	/usr/local/go/src/github.com/kevinburke/go-bindata (from $GOROOT)
	$GOLANG_WORKSPACE/src/github.com/kevinburke/go-bindata (from $GOPATH)
$ popd
$ go mod init github.com/kevinburke/go-bindata
$ pushd go-bindata
$ go build -v
github.com/kevinburke/go-bindata
github.com/kevinburke/go-bindata/go-bindata
```

Closes https://github.com/kevinburke/go-bindata/issues/18