### PR TITLE
Bump CI to go 1.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go_import_path: github.com/kevinburke/go-bindata
 language: go
 
 go:
-  - '1.13.x'
+  - '1.14.x'
   - master
 
 script:
@@ -12,5 +12,3 @@ script:
   - find testdata/in -type f | xargs chmod 0644
   - make ci
   - make bench
-
-sudo: false


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/52294 (homebrew side tested with latest golang release)