### PR TITLE
Remove superfluous type specification

### DIFF
--- a/testdata/out/compress-memcopy.go
+++ b/testdata/out/compress-memcopy.go
@@ -293,17 +293,17 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"in": &bintree{nil, map[string]*bintree{
-		"a": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inATestAsset, map[string]*bintree{}},
+	"in": {nil, map[string]*bintree{
+		"a": {nil, map[string]*bintree{
+			"test.asset": {inATestAsset, map[string]*bintree{}},
 		}},
-		"b": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inBTestAsset, map[string]*bintree{}},
+		"b": {nil, map[string]*bintree{
+			"test.asset": {inBTestAsset, map[string]*bintree{}},
 		}},
-		"c": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inCTestAsset, map[string]*bintree{}},
+		"c": {nil, map[string]*bintree{
+			"test.asset": {inCTestAsset, map[string]*bintree{}},
 		}},
-		"test.asset": &bintree{inTestAsset, map[string]*bintree{}},
+		"test.asset": {inTestAsset, map[string]*bintree{}},
 	}},
 }}
 

--- a/testdata/out/compress-nomemcopy.go
+++ b/testdata/out/compress-nomemcopy.go
@@ -294,17 +294,17 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"in": &bintree{nil, map[string]*bintree{
-		"a": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inATestAsset, map[string]*bintree{}},
+	"in": {nil, map[string]*bintree{
+		"a": {nil, map[string]*bintree{
+			"test.asset": {inATestAsset, map[string]*bintree{}},
 		}},
-		"b": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inBTestAsset, map[string]*bintree{}},
+		"b": {nil, map[string]*bintree{
+			"test.asset": {inBTestAsset, map[string]*bintree{}},
 		}},
-		"c": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inCTestAsset, map[string]*bintree{}},
+		"c": {nil, map[string]*bintree{
+			"test.asset": {inCTestAsset, map[string]*bintree{}},
 		}},
-		"test.asset": &bintree{inTestAsset, map[string]*bintree{}},
+		"test.asset": {inTestAsset, map[string]*bintree{}},
 	}},
 }}
 

--- a/testdata/out/debug.go
+++ b/testdata/out/debug.go
@@ -244,17 +244,17 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"in": &bintree{nil, map[string]*bintree{
-		"a": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inATestAsset, map[string]*bintree{}},
+	"in": {nil, map[string]*bintree{
+		"a": {nil, map[string]*bintree{
+			"test.asset": {inATestAsset, map[string]*bintree{}},
 		}},
-		"b": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inBTestAsset, map[string]*bintree{}},
+		"b": {nil, map[string]*bintree{
+			"test.asset": {inBTestAsset, map[string]*bintree{}},
 		}},
-		"c": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inCTestAsset, map[string]*bintree{}},
+		"c": {nil, map[string]*bintree{
+			"test.asset": {inCTestAsset, map[string]*bintree{}},
 		}},
-		"test.asset": &bintree{inTestAsset, map[string]*bintree{}},
+		"test.asset": {inTestAsset, map[string]*bintree{}},
 	}},
 }}
 

--- a/testdata/out/nocompress-memcopy.go
+++ b/testdata/out/nocompress-memcopy.go
@@ -262,17 +262,17 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"in": &bintree{nil, map[string]*bintree{
-		"a": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inATestAsset, map[string]*bintree{}},
+	"in": {nil, map[string]*bintree{
+		"a": {nil, map[string]*bintree{
+			"test.asset": {inATestAsset, map[string]*bintree{}},
 		}},
-		"b": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inBTestAsset, map[string]*bintree{}},
+		"b": {nil, map[string]*bintree{
+			"test.asset": {inBTestAsset, map[string]*bintree{}},
 		}},
-		"c": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inCTestAsset, map[string]*bintree{}},
+		"c": {nil, map[string]*bintree{
+			"test.asset": {inCTestAsset, map[string]*bintree{}},
 		}},
-		"test.asset": &bintree{inTestAsset, map[string]*bintree{}},
+		"test.asset": {inTestAsset, map[string]*bintree{}},
 	}},
 }}
 

--- a/testdata/out/nocompress-nomemcopy.go
+++ b/testdata/out/nocompress-nomemcopy.go
@@ -283,17 +283,17 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"in": &bintree{nil, map[string]*bintree{
-		"a": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inATestAsset, map[string]*bintree{}},
+	"in": {nil, map[string]*bintree{
+		"a": {nil, map[string]*bintree{
+			"test.asset": {inATestAsset, map[string]*bintree{}},
 		}},
-		"b": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inBTestAsset, map[string]*bintree{}},
+		"b": {nil, map[string]*bintree{
+			"test.asset": {inBTestAsset, map[string]*bintree{}},
 		}},
-		"c": &bintree{nil, map[string]*bintree{
-			"test.asset": &bintree{inCTestAsset, map[string]*bintree{}},
+		"c": {nil, map[string]*bintree{
+			"test.asset": {inCTestAsset, map[string]*bintree{}},
 		}},
-		"test.asset": &bintree{inTestAsset, map[string]*bintree{}},
+		"test.asset": {inTestAsset, map[string]*bintree{}},
 	}},
 }}
 

--- a/toc.go
+++ b/toc.go
@@ -57,7 +57,7 @@ func (root *assetTree) funcOrNil() string {
 
 func (root *assetTree) writeGoMap(buf *bytes.Buffer, nident int) {
 	buf.Grow(35) // at least this size
-	fmt.Fprintf(buf, "&bintree{%s, map[string]*bintree{", root.funcOrNil())
+	fmt.Fprintf(buf, "{%s, map[string]*bintree{", root.funcOrNil())
 
 	if len(root.Children) > 0 {
 		buf.WriteByte('\n')


### PR DESCRIPTION
The type of the value in the map is inferred from the
map type, so is superfluous. gofmt -s simplifies this
away, and so can we.

Fixes #35