### PR TITLE
all: use "v3" module path

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	bindata "github.com/kevinburke/go-bindata"
+	bindata "github.com/kevinburke/go-bindata/v3"
 )
 
 func dirSize(path string) (int64, error) {

--- a/convert_test.go
+++ b/convert_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kevinburke/go-bindata/testdata/assets"
+	"github.com/kevinburke/go-bindata/v3/testdata/assets"
 )
 
 func TestSafeFunctionName(t *testing.T) {

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/kevinburke/go-bindata"
+	"github.com/kevinburke/go-bindata/v3"
 )
 
 func main() {
@@ -97,9 +97,9 @@ func parseArgs() *bindata.Config {
 // parseRecursive determines whether the given path has a recursive indicator and
 // returns a new path with the recursive indicator chopped off if it does.
 //
-//  ex:
-//      /path/to/foo/...    -> (/path/to/foo, true)
-//      /path/to/bar        -> (/path/to/bar, false)
+//	ex:
+//	    /path/to/foo/...    -> (/path/to/foo, true)
+//	    /path/to/bar        -> (/path/to/bar, false)
 func parseInput(path string) bindata.InputConfig {
 	if strings.HasSuffix(path, "/...") {
 		return bindata.InputConfig{

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/kevinburke/go-bindata
+module github.com/kevinburke/go-bindata/v3
 
 go 1.19


### PR DESCRIPTION
I think this will make sure the right thing is returned when you run "go install ...@latest"