### PR TITLE
build: set dependabot schedules to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Update the existing Dependabot configuration to check Go modules and
GitHub Actions dependencies daily instead of weekly.

These are the relevant ecosystems present in this repository, so no
additional Dependabot updates were needed.

